### PR TITLE
fix: prevent view removal during Triangle binding update

### DIFF
--- a/src/fast/tree.ts
+++ b/src/fast/tree.ts
@@ -53,11 +53,11 @@ export class Dot extends FASTElement {
 }
 
 
-const halfTemplate = html<Triangle>`
+const dotTemplate = html<Triangle>`
         <f-dot :x=${(x) => x.x - HALF_TARGET_SIZE} :y=${(x) => x.y - HALF_TARGET_SIZE} :size=${() => TARGET_SIZE} :text=${(x) => x.text}></f-dot>
 `;
 
-const otherTemplate =  html<Triangle>`
+const trippleTriangleTemplate =  html<Triangle>`
   <f-triangle :x=${(x) => x.x} :y=${(x) => x.y - half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
   <f-triangle :x=${(x) => x.x - half(x.s)} :y=${(x) => x.y + half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
   <f-triangle :x=${(x) => x.x + half(x.s)} :y=${(x) => x.y + half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
@@ -69,7 +69,7 @@ const otherTemplate =  html<Triangle>`
  */
 @customElement({
   name: 'f-triangle',
-  template: halfTemplate,
+  template: dotTemplate,
 })
 export class Triangle extends FASTElement {
   public x = 0;
@@ -82,7 +82,7 @@ export class Triangle extends FASTElement {
     observe(this, 'x', 'y', 's', 'text');
     Observable.getNotifier(this).subscribe({
       handleChange: () => {
-        this.$fastController.template = this.s <= 25 ? halfTemplate : otherTemplate
+        this.$fastController.template = this.s <= 25 ? dotTemplate : trippleTriangleTemplate
       }
     }, "s");
   }

--- a/src/fast/tree.ts
+++ b/src/fast/tree.ts
@@ -1,7 +1,11 @@
-import { FASTElement, customElement, html } from '@microsoft/fast-element';
+import { FASTElement, Observable, customElement, html } from '@microsoft/fast-element';
 import { observe } from './observe';
 
+function half(num: number) {
+  return num / 2;
+}
 const TARGET_SIZE = 25;
+const HALF_TARGET_SIZE = half(TARGET_SIZE);
 
 /**
  * ------------------------------------------------------------------------------------------
@@ -49,6 +53,15 @@ export class Dot extends FASTElement {
 }
 
 
+const halfTemplate = html<Triangle>`
+        <f-dot :x=${(x) => x.x - HALF_TARGET_SIZE} :y=${(x) => x.y - HALF_TARGET_SIZE} :size=${() => TARGET_SIZE} :text=${(x) => x.text}></f-dot>
+`;
+
+const otherTemplate =  html<Triangle>`
+  <f-triangle :x=${(x) => x.x} :y=${(x) => x.y - half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
+  <f-triangle :x=${(x) => x.x - half(x.s)} :y=${(x) => x.y + half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
+  <f-triangle :x=${(x) => x.x + half(x.s)} :y=${(x) => x.y + half(half(x.s))} :s=${(x) => half(x.s)} :text=${(x) => x.text}></f-triangle>
+ `;
 /**
  * ------------------------------------------------------------------------------------------
  * The Triangle Component
@@ -56,23 +69,7 @@ export class Dot extends FASTElement {
  */
 @customElement({
   name: 'f-triangle',
-  template: html`${(e: Triangle) => {
-    const { x, y, text } = e;
-    let s = e.s;
-    if (s <= TARGET_SIZE) {
-      const half = TARGET_SIZE / 2;
-      return html`
-        <f-dot :x=${() => x - half} :y=${() => y - half} :size=${() => TARGET_SIZE} :text=${() => text}></f-dot>
-      `;
-    }
-    s /= 2;
-    const half = s / 2;
-    return html`
-      <f-triangle :x=${() => x} :y=${() => y - half} :s=${() => s} :text=${() => text}></f-triangle>
-      <f-triangle :x=${() => x - s} :y=${() => y + half} :s=${() => s} :text=${() => text}></f-triangle>
-      <f-triangle :x=${() => x + s} :y=${() => y + half} :s=${() => s} :text=${() => text}></f-triangle>
-    `;
-  }}`,
+  template: halfTemplate,
 })
 export class Triangle extends FASTElement {
   public x = 0;
@@ -83,6 +80,11 @@ export class Triangle extends FASTElement {
   constructor() {
     super();
     observe(this, 'x', 'y', 's', 'text');
+    Observable.getNotifier(this).subscribe({
+      handleChange: () => {
+        this.$fastController.template = this.s <= 25 ? halfTemplate : otherTemplate
+      }
+    }, "s");
   }
 }
 


### PR DESCRIPTION
This PR fixes a critical flaw in the Triangle component's template that was causing significant negative performance impacts.

There are two problems in this specific template implementation. The first is that is does not leverage the benefits of template caching. The binding returns a _new template instance_ every invocation of the binding, which happens every second. This creation work is being done for _all triangle components_ every second. That is a ton of un-necessary work. By storing a reference to the two components being used, and applying the template conditionally, we can reduce the number of template instances being leveraged by _all triangle elements_ to **two**, and they are only ever created during initialization. 

The second is related to the first: when the binding evaluates and returns a *new template*, the templating engine must tear down the old view and instantiate a new one from the new template. This tearing down entails _removing all elements in that view from the document_. This is really bad because it means each second, every element in every Triangle component is being removed.

This PR changes the code to leverage template caching, which *also* fixes the issue of the views being unbound and rebound every animation frame, improving runtime performance of the tree experience considerably. 